### PR TITLE
cloudformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# aws-cloudformation-template
-AWS CloudFormation Template for EC2, ALB, and VPC

--- a/aws-cloudformation-docker/vpc-stack.yaml
+++ b/aws-cloudformation-docker/vpc-stack.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'CloudFormation template to deploy a VPC with public and private subnets, an ALB, an EC2 instance with Apache2, and a NAT Gateway.'
+Description: 'Deploy a VPC with public and private subnets, an ALB, two EC2 instances running Docker Swarm, and a NAT Gateway.'
 
 Resources:
   VPC:
@@ -80,6 +80,7 @@ Resources:
 
   NATGateway:
     Type: AWS::EC2::NatGateway
+    DependsOn: ElasticIP
     Properties:
       AllocationId: !GetAtt ElasticIP.AllocationId
       SubnetId: !Ref PublicSubnet
@@ -94,34 +95,7 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId: !Ref NATGateway
 
-  JumpServer:
-    Type: AWS::EC2::Instance
-    Properties:
-      InstanceType: t2.micro
-      KeyName: oregon-test
-      ImageId: ami-00c257e12d6828491
-      NetworkInterfaces:
-        - AssociatePublicIpAddress: true
-          SubnetId: !Ref PublicSubnet
-          GroupSet:
-            - !Ref JumpServerSecurityGroup
-          DeviceIndex: 0
-      Tags:
-        - Key: Name
-          Value: JumpServer
-
-  JumpServerSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Allow SSH access
-      VpcId: !Ref VPC
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: 0.0.0.0/0
-
-  WebServer:
+  DockerInstance1:
     Type: AWS::EC2::Instance
     Properties:
       InstanceType: t2.micro
@@ -135,29 +109,74 @@ Resources:
           DeviceIndex: 0
       Tags:
         - Key: Name
-          Value: WebServer
+          Value: DockerInstance1
       UserData:
         Fn::Base64: |
           #!/bin/bash
           apt update -y
-          apt install apache2 unzip -y
-          systemctl start apache2
-          cd /var/www/html/
+          apt install -y docker.io unzip
+          systemctl start docker
+          systemctl enable docker
+          docker swarm init --advertise-addr $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+          docker pull httpd:latest
+          mkdir -p /var/www/html
+          cd /var/www/html
           wget http://www.tooplate.com/zip-templates/2132_clean_work.zip
           unzip 2132_clean_work.zip
-          mv index.html index.html.old
-          cp -R 2132_clean_work/* .
+          mv 2132_clean_work/* .
+          docker service create --name apache --replicas 2 -p 80:80 --mount type=bind,source=/var/www/html,target=/usr/local/apache2/htdocs httpd:latest
+
+  DockerInstance2:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: t2.micro
+      KeyName: oregon-test
+      ImageId: ami-00c257e12d6828491
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: false
+          SubnetId: !Ref PrivateSubnet
+          GroupSet:
+            - !Ref WebServerSecurityGroup
+          DeviceIndex: 0
+      Tags:
+        - Key: Name
+          Value: DockerInstance2
+      UserData:
+        Fn::Base64: |
+          #!/bin/bash
+          apt update -y
+          apt install -y docker.io unzip
+          systemctl start docker
+          systemctl enable docker
+          MANAGER_IP=$(aws ec2 describe-instances --region us-west-2 --filters "Name=tag:Name,Values=DockerInstance1" --query "Reservations[].Instances[].PrivateIpAddress" --output text)
+          docker swarm join --token $(docker swarm join-token -q worker) $MANAGER_IP:2377
 
   WebServerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Allow HTTP access from ALB
+      GroupDescription: Allow HTTP and Docker Swarm traffic
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           SourceSecurityGroupId: !Ref ALBSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 2377
+          ToPort: 2377
+          SourceSecurityGroupId: !Ref WebServerSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 7946
+          ToPort: 7946
+          SourceSecurityGroupId: !Ref WebServerSecurityGroup
+        - IpProtocol: udp
+          FromPort: 7946
+          ToPort: 7946
+          SourceSecurityGroupId: !Ref WebServerSecurityGroup
+        - IpProtocol: udp
+          FromPort: 4789
+          ToPort: 4789
+          SourceSecurityGroupId: !Ref WebServerSecurityGroup
 
   ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -175,14 +194,10 @@ Resources:
     Properties:
       Name: ALB
       Scheme: internet-facing
-      LoadBalancerAttributes:
-        - Key: idle_timeout.timeout_seconds
-          Value: '60'
       SecurityGroups:
         - !Ref ALBSecurityGroup
       Subnets:
         - !Ref PublicSubnet
-        - !Ref PrivateSubnet
 
   Listener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -202,8 +217,12 @@ Resources:
       Protocol: HTTP
       VpcId: !Ref VPC
       TargetType: instance
+      HealthCheckPath: /
+      HealthCheckPort: 80
+      HealthCheckProtocol: HTTP
       Targets:
-        - Id: !Ref WebServer
+        - Id: !Ref DockerInstance1
+        - Id: !Ref DockerInstance2
 
 Outputs:
   LoadBalancerDNS:

--- a/aws-cloudformation-ec2/dmz-network-zome.yaml
+++ b/aws-cloudformation-ec2/dmz-network-zome.yaml
@@ -143,10 +143,10 @@ Resources:
           apt install apache2 unzip -y
           systemctl start apache2
           cd /var/www/html/
-          wget http://www.tooplate.com/zip-templates/2132_clean_work.zip
-          unzip 2132_clean_work.zip
+          wget https://www.tooplate.com/view/2129-crispy-kitchen
+          unzip 2129-crispy-kitchen.zip
           mv index.html index.html.old
-          cp -R 2132_clean_work/* .
+          cp -R 2129-crispy-kitchen/* .
 
   WebServerSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
AWSTemplateFormatVersion: '2010-09-09'
Description: 'CloudFormation template to deploy a VPC with public and private subnets, an ALB, an EC2 instance with Apache2, and a NAT Gateway.'

Resources:
  VPC:
    Type: AWS::EC2::VPC
    Properties:
      CidrBlock: 10.0.0.0/16
      EnableDnsSupport: true
      EnableDnsHostnames: true
      Tags:
        - Key: Name
          Value: CustomVPC

  PublicSubnet:
    Type: AWS::EC2::Subnet
    Properties:
      VpcId: !Ref VPC
      CidrBlock: 10.0.1.0/24
      AvailabilityZone: us-west-2a
      MapPublicIpOnLaunch: true
      Tags:
        - Key: Name
          Value: PublicSn

  PrivateSubnet:
    Type: AWS::EC2::Subnet
    Properties:
      VpcId: !Ref VPC
      CidrBlock: 10.0.2.0/24
      AvailabilityZone: us-west-2b
      MapPublicIpOnLaunch: false
      Tags:
        - Key: Name
          Value: PrivateSn

  InternetGateway:
    Type: AWS::EC2::InternetGateway

  AttachGateway:
    Type: AWS::EC2::VPCGatewayAttachment
    Properties:
      VpcId: !Ref VPC
      InternetGatewayId: !Ref InternetGateway

  PublicRouteTable:
    Type: AWS::EC2::RouteTable
    Properties:
      VpcId: !Ref VPC

  PublicRoute:
    Type: AWS::EC2::Route
    DependsOn: AttachGateway
    Properties:
      RouteTableId: !Ref PublicRouteTable
      DestinationCidrBlock: 0.0.0.0/0
      GatewayId: !Ref InternetGateway

  PublicSubnetRouteTableAssociation:
    Type: AWS::EC2::SubnetRouteTableAssociation
    Properties:
      SubnetId: !Ref PublicSubnet
      RouteTableId: !Ref PublicRouteTable

  PrivateRouteTable:
    Type: AWS::EC2::RouteTable
    Properties:
      VpcId: !Ref VPC

  PrivateSubnetRouteTableAssociation:
    Type: AWS::EC2::SubnetRouteTableAssociation
    Properties:
      SubnetId: !Ref PrivateSubnet
      RouteTableId: !Ref PrivateRouteTable

  ElasticIP:
    Type: AWS::EC2::EIP
    Properties:
      Domain: vpc

  NATGateway:
    Type: AWS::EC2::NatGateway
    Properties:
      AllocationId: !GetAtt ElasticIP.AllocationId
      SubnetId: !Ref PublicSubnet
      Tags:
        - Key: Name
          Value: NATGateway

  PrivateRoute:
    Type: AWS::EC2::Route
    Properties:
      RouteTableId: !Ref PrivateRouteTable
      DestinationCidrBlock: 0.0.0.0/0
      NatGatewayId: !Ref NATGateway

  JumpServer:
    Type: AWS::EC2::Instance
    Properties:
      InstanceType: t2.micro
      KeyName: oregon-test
      ImageId: ami-00c257e12d6828491
      NetworkInterfaces:
        - AssociatePublicIpAddress: true
          SubnetId: !Ref PublicSubnet
          GroupSet:
            - !Ref JumpServerSecurityGroup
          DeviceIndex: 0
      Tags:
        - Key: Name
          Value: JumpServer

  JumpServerSecurityGroup:
    Type: AWS::EC2::SecurityGroup
    Properties:
      GroupDescription: Allow SSH access
      VpcId: !Ref VPC
      SecurityGroupIngress:
        - IpProtocol: tcp
          FromPort: 22
          ToPort: 22
          CidrIp: 0.0.0.0/0

  WebServer:
    Type: AWS::EC2::Instance
    Properties:
      InstanceType: t2.micro
      KeyName: oregon-test
      ImageId: ami-00c257e12d6828491
      NetworkInterfaces:
        - AssociatePublicIpAddress: false
          SubnetId: !Ref PrivateSubnet
          GroupSet:
            - !Ref WebServerSecurityGroup
          DeviceIndex: 0
      Tags:
        - Key: Name
          Value: WebServer
      UserData:
        Fn::Base64: |
          #!/bin/bash
          apt update -y
          apt install apache2 unzip -y
          systemctl start apache2
          cd /var/www/html/
          wget https://www.tooplate.com/view/2129-crispy-kitchen
          unzip 2129-crispy-kitchen.zip
          mv index.html index.html.old
          cp -R 2129-crispy-kitchen/* .

  WebServerSecurityGroup:
    Type: AWS::EC2::SecurityGroup
    Properties:
      GroupDescription: Allow HTTP access from ALB
      VpcId: !Ref VPC
      SecurityGroupIngress:
        - IpProtocol: tcp
          FromPort: 80
          ToPort: 80
          SourceSecurityGroupId: !Ref ALBSecurityGroup

  ALBSecurityGroup:
    Type: AWS::EC2::SecurityGroup
    Properties:
      GroupDescription: Allow HTTP access
      VpcId: !Ref VPC
      SecurityGroupIngress:
        - IpProtocol: tcp
          FromPort: 80
          ToPort: 80
          CidrIp: 0.0.0.0/0

  ApplicationLoadBalancer:
    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
    Properties:
      Name: ALB
      Scheme: internet-facing
      LoadBalancerAttributes:
        - Key: idle_timeout.timeout_seconds
          Value: '60'
      SecurityGroups:
        - !Ref ALBSecurityGroup
      Subnets:
        - !Ref PublicSubnet
        - !Ref PrivateSubnet

  Listener:
    Type: AWS::ElasticLoadBalancingV2::Listener
    Properties:
      DefaultActions:
        - Type: forward
          TargetGroupArn: !Ref TargetGroup
      LoadBalancerArn: !Ref ApplicationLoadBalancer
      Port: 80
      Protocol: HTTP

  TargetGroup:
    Type: AWS::ElasticLoadBalancingV2::TargetGroup
    Properties:
      Name: TargetGroup
      Port: 80
      Protocol: HTTP
      VpcId: !Ref VPC
      TargetType: instance
      Targets:
        - Id: !Ref WebServer

Outputs:
  LoadBalancerDNS:
    Description: ALB DNS Name
    Value: !GetAtt ApplicationLoadBalancer.DNSName